### PR TITLE
Update collect.R

### DIFF
--- a/R/collect.R
+++ b/R/collect.R
@@ -152,7 +152,9 @@ collect_baseline <- function(
 
   # standardize categorical variables
   if (any(c("factor", "character") %in% class_var)) {
-    var <- factor(var, exclude = NULL)
+    if (any(c("character") %in% class_var)) {
+      var <- factor(var, exclude = NULL)
+    }
 
     if (all(is.na(var))) {
       levels(var) <- c(levels(var), title["missing"])


### PR DESCRIPTION
```
library(r2rtf)

meta <- metalite::meta_example()

meta$data_population$TRTA <- factor(meta$data_population$TRTA)
# Level SEX
meta$data_population$SEX <- factor(meta$data_population$SEX, levels = c("F", "M", "Unknown"))

meta <- meta |>
define_parameter(name = "sex", var = "SEX", label = "Sex")

collect_baseline(meta, "apat", "sex")
```

Expect output:

```
$pop
  name  Placebo Xanomeline Low Dose Xanomeline High Dose    Total var_label
1    F 61.62791            59.52381             47.61905 56.29921       Sex
2    M 38.37209            40.47619             52.38095 43.70079       Sex
3 Unknown 0               0                            0               0                SEX
```

Since refactor the SEX variable, output is not showing row for Unknown as expected.

```
$pop
  name  Placebo Xanomeline Low Dose Xanomeline High Dose    Total var_label
1    F 61.62791            59.52381             47.61905 56.29921       Sex
2    M 38.37209            40.47619             52.38095 43.70079       Sex
```