### PR TITLE
metalite.sl: Create vignettes for exposure duration table

### DIFF
--- a/R/rtf_sl_summary.R
+++ b/R/rtf_sl_summary.R
@@ -109,7 +109,7 @@ rtf_sl_summary <- function(
     # combine with user defined footnotes if not NULL
     if (nchar(footnotes_stat) > 0) {
       if (!is.null(footnotes)) {
-        footnotes <- paste0(footnotes_stat, ".\n", footnotes)
+        footnotes <- c(paste0(footnotes_stat, "."), footnotes)
       } else {
         footnotes <- paste0(footnotes_stat, ".")
       }

--- a/tests/testthat/_snaps/independent-testing-rtf_exp_duration/exp0duration1.rtf
+++ b/tests/testthat/_snaps/independent-testing-rtf_exp_duration/exp0duration1.rtf
@@ -276,7 +276,7 @@
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx9000
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 SD=Standard deviation; SE=Standard error; Q1=First quartile, Q3=Third quartile.\line Each participant is counted once on each applicable duration category row.\line SD=Standard deviation; SE=Standard error; Q1=First quartile, Q3=Third quartile.\line Duration of Exposure is the time from the first dose date to the last dose date.}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 SD=Standard deviation; SE=Standard error; Q1=First quartile, Q3=Third quartile.\line Each participant is counted once on each applicable duration category row.\line Duration of Exposure is the time from the first dose date to the last dose date.}\cell
 \intbl\row\pard
 {\pard\hyphpar\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Source: [CDISCpilot: adam-adexsum]}\par}
 

--- a/tests/testthat/_snaps/independent-testing-rtf_exp_duration/exp0duration2.rtf
+++ b/tests/testthat/_snaps/independent-testing-rtf_exp_duration/exp0duration2.rtf
@@ -384,7 +384,7 @@
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx12240
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 SD=Standard deviation; SE=Standard error; Q1=First quartile, Q3=Third quartile.\line Each participant is counted once on each applicable duration category row.\line SD=Standard deviation; SE=Standard error; Q1=First quartile, Q3=Third quartile.\line Duration of Exposure is the time from the first dose date to the last dose date.}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 SD=Standard deviation; SE=Standard error; Q1=First quartile, Q3=Third quartile.\line Each participant is counted once on each applicable duration category row.\line Duration of Exposure is the time from the first dose date to the last dose date.}\cell
 \intbl\row\pard
 {\pard\hyphpar\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Source: [CDISCpilot: adam-adexsum]}\par}
 

--- a/tests/testthat/_snaps/independent-testing-rtf_exp_duration/exp0duration3.rtf
+++ b/tests/testthat/_snaps/independent-testing-rtf_exp_duration/exp0duration3.rtf
@@ -338,7 +338,7 @@
 \intbl\row\pard
 \trowd\trgaph108\trleft0\trqc
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx9000
-\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 SD=Standard deviation; SE=Standard error; Q1=First quartile, Q3=Third quartile.\line Each participant is counted once on each applicable duration category row.\line SD=Standard deviation; SE=Standard error; Q1=First quartile, Q3=Third quartile.\line Duration of Exposure is the time from the first dose date to the last dose date.}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 SD=Standard deviation; SE=Standard error; Q1=First quartile, Q3=Third quartile.\line Each participant is counted once on each applicable duration category row.\line Duration of Exposure is the time from the first dose date to the last dose date.}\cell
 \intbl\row\pard
 {\pard\hyphpar\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Source: [CDISCpilot: adam-adexsum]}\par}
 

--- a/vignettes/exp_duration.Rmd
+++ b/vignettes/exp_duration.Rmd
@@ -14,7 +14,6 @@ vignette: >
 ---
 
 ```{r}
-devtools::load_all()
 library(metalite)
 library(metalite.sl)
 ```

--- a/vignettes/exp_duration.Rmd
+++ b/vignettes/exp_duration.Rmd
@@ -1,0 +1,158 @@
+---
+title: "Getting Started with Exposure Duration Table"
+output:
+  rmarkdown::html_document:
+    toc: true
+    toc_float: true
+    toc_depth: 2
+    number_sections: true
+    highlight: "textmate"
+    css: "custom.css"
+vignette: >
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteIndexEntry{Getting Started with Exposure Duration Table}
+---
+
+```{r}
+devtools::load_all()
+library(metalite)
+library(metalite.sl)
+```
+
+# Create Exposure Duration Table
+
+The exposure duration analysis aims to provide table to summarize by each identified duration category.
+The development of exposure duration analysis involves functions:
+
+- `meta_sl_exposure_example`: build the metadata (`meta` object) for analysis.
+- `prepare_exp_duration`: prepare analysis raw datasets.
+- `format_exp_duration`: prepare analysis outdata with proper format.
+- `rtf_exp_duration`: transfer (mock) output dataset to RTF table.
+
+## Build a metadata
+
+There are two steps in `meta_sl_exposure_example` function in order to build the metadata (`meta` object): processing the ADaM dataset and save meta information for A&R reporting.
+
+Step1: ADEXSUM, the ADaM dataset for Drug Exposrue Summary Data, is utilized to:
+
+- Sum up duration by STUDYID SITENUM USUBJID SUBJID APERIOD EXTRT ADOSEFRM PARAMCD.
+- Subset the exposure data by `upcase(trim(left(paramcd))) = "TRTDUR"`.
+- Get the exposure duration `adexsum$AVAL` for all participants.
+- Assign duration category `adexsum$EXDURGR` i.e.">=1 day", ">=7 days",">=28 days", ">=12 weeks" and ">=24 weeks".
+
+```{r}
+  adsl <- r2rtf::r2rtf_adsl
+  adexsum <- data.frame(USUBJID=adsl$USUBJID)
+  adexsum$TRTA <- factor(adsl$TRT01A,
+                         levels = c("Placebo", "Xanomeline Low Dose", "Xanomeline High Dose"),
+                         labels = c("Placebo", "Low Dose", "High Dose")
+  )
+  
+  adexsum$APERIODC <- "Base"
+  adexsum$APERIOD <- 1
+  
+  set.seed(123)  # Set a seed for reproducibility
+  adexsum$AVAL <- sample(x = 0:(24*7), size = length(adexsum$USUBJID), replace = TRUE)
+  adexsum$EXDURGR <- "not treated"
+  adexsum$EXDURGR[adexsum$AVAL>=1] <- ">=1 day"
+  adexsum$EXDURGR[adexsum$AVAL>=7] <- ">=7 days"
+  adexsum$EXDURGR[adexsum$AVAL>=28] <- ">=28 days"
+  adexsum$EXDURGR[adexsum$AVAL>=12*7] <- ">=12 weeks"
+  adexsum$EXDURGR[adexsum$AVAL>=24*7] <- ">=24 weeks"
+  
+  adexsum$EXDURGR <- factor(adexsum$EXDURGR,
+                            levels = c("not treated", ">=1 day", ">=7 days", ">=28 days", ">=12 weeks", ">=24 weeks"))
+unique(adexsum$EXDURGR)
+```
+
+Step2: Save analysis plan and metadata(parameter and analysis) information, then build meta object.
+
+```{r}
+plan <- metalite::plan(
+    analysis = "exp_dur", population = "apat",
+    observation = "apat", parameter = "expdur"
+  ) 
+  
+meta <- metalite::meta_adam(
+    population = adexsum,
+    observation = adexsum
+  ) |>
+    metalite::define_plan(plan) |>
+    metalite::define_population(
+      name = "apat",
+      group = "TRTA",
+      subset = quote(APERIOD==1 & AVAL>0)
+    ) |>
+    metalite::define_parameter(
+      name = "expdur",
+      var = "AVAL",
+      label = "Exposure Duration (Days)",
+      vargroup = "EXDURGR"
+    )|>
+    metalite::define_analysis(
+      name = "exp_dur",
+      title = "Summary of Exposure Duration",
+      label = "exposure duration table"
+    ) |>
+    metalite::meta_build()
+```
+
+## Analysis preparation
+
+The input of the function `prepare_exp_duration()` is a `meta` object created by the metalite package. The resulting output comprises a collection of raw datasets for analysis and reporting.
+
+```{r}
+outdata <- prepare_exp_duration(meta)
+outdata
+```
+
+Number of participants in population
+
+```{r}
+outdata$n[,1:5]
+```
+
+Number of participants in each duration category
+
+```{r}
+charn<-data.frame(outdata$char_n[1])
+head(charn[,1:5],6) 
+```
+
+Proportion of participants in each duration category
+
+```{r}
+charp<-data.frame(outdata$char_prop[1])
+head(charp[,1:5],6)
+```
+
+Statistical summary of exposure duration for each treatment
+
+```{r}
+chars<-data.frame(outdata$char_n[1])
+tail(chars[,1:5],8) 
+```
+
+## Format output
+
+`format_exp_duration` to prepare analysis dataset before generate RTF output
+
+```{r}
+tbl <- format_exp_duration(outdata)
+head(tbl$tbl)
+```
+
+
+## Output as RTF
+
+`rtf_exp_duration` to generate RTF output
+
+```{r, warning=FALSE}
+outdata <- format_exp_duration(outdata) |>
+  rtf_exp_duration(
+    source = "Source:  [CDISCpilot: adam-adexsum]",
+    path_outdata = tempfile(fileext = ".Rdata"),
+    path_outtable = "outtable/exp0duration.rtf"
+  )
+```
+

--- a/vignettes/outtable/exp0duration.rtf
+++ b/vignettes/outtable/exp0duration.rtf
@@ -1,0 +1,345 @@
+{\rtf1\ansi
+\deff0\deflang1033
+{\fonttbl{\f0\froman\fcharset161\fprq2 Times New Roman;}
+{\f1\froman\fcharset161\fprq2 Times New Roman Greek;}
+{\f2\fswiss\fcharset161\fprq2 Arial Greek;}
+{\f3\fswiss\fcharset161\fprq2 Arial;}
+{\f4\fswiss\fcharset161\fprq2 Helvetica;}
+{\f5\fswiss\fcharset161\fprq2 Calibri;}
+{\f6\froman\fcharset161\fprq2 Georgia;}
+{\f7\ffroman\fcharset161\fprq2 Cambria;}
+{\f8\fmodern\fcharset161\fprq2 Courier New;}
+{\f9\ftech\fcharset161\fprq2 Symbol;}
+}
+
+
+\paperw12240\paperh15840
+
+\margl1800\margr1440\margt2520\margb1800\headery2520\footery1449
+
+{\pard\hyphpar\sb180\sa180\fi0\li0\ri0\qc\fs24{\f0 Summary of Exposure Duration}\line\fs24{\f0 All Participants as Treated}\par}
+
+
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2455
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4091
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5727
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7363
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrdb\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8999
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Placebo}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Low Dose}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 High Dose}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Total}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalb\cellx2455
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx3273
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4091
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx4909
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx5727
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx6545
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx7363
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8181
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalb\cellx8999
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 n}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (%)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2455
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3273
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4091
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4909
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5727
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6545
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7363
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8181
+\clbrdrl\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8999
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 Participants in population}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 86}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 83}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 84}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 253}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrs\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0\b Exposure Duration (Days)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2455
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3273
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4091
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4909
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5727
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6545
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7363
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8181
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8999
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 not treated}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2455
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3273
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4091
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4909
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5727
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6545
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7363
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8181
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8999
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 \uc1\u8805* 1 day}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 2}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (2.3)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 4}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (4.8)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.6)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 9}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (3.6)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2455
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3273
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4091
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4909
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5727
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6545
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7363
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8181
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8999
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 \uc1\u8805* 7 days}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 13}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (15.1)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 11}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (13.3)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 9}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (10.7)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 33}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (13.0)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2455
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3273
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4091
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4909
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5727
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6545
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7363
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8181
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8999
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 \uc1\u8805* 28 days}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 31}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (36.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 20}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (24.1)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 27}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (32.1)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 78}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (30.8)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2455
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3273
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4091
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4909
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5727
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6545
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7363
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8181
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8999
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 \uc1\u8805* 12 weeks}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 39}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (45.3)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 48}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (57.8)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 45}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (53.6)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 132}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 (52.2)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2455
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3273
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4091
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4909
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5727
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6545
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7363
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8181
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8999
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 \uc1\u8805* 24 weeks}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.0)}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (0.4)}\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2455
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3273
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4091
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4909
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5727
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6545
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7363
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8181
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8999
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2455
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3273
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4091
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4909
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5727
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6545
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7363
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8181
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8999
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Mean}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 81.5}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 90.8}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 87.6}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 86.6}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2455
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3273
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4091
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4909
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5727
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6545
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7363
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8181
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8999
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 SD}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 49.1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 51.3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 48.8}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 49.7}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2455
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3273
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4091
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4909
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5727
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6545
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7363
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8181
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8999
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 SE}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 5.3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 5.6}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 5.3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3.1}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2455
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3273
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4091
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4909
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5727
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6545
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7363
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8181
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8999
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Median}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 76.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 93.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 90.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 88.0}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx2455
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx3273
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4091
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx4909
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx5727
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6545
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7363
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8181
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8999
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Q1 to Q3}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 41.25 to 123.25}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 48 to 137.5}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 44.75 to 129.25}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 44 to 133}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx2455
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx3273
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4091
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx4909
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx5727
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx6545
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx7363
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8181
+\clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrs\brdrw15\clvertalt\cellx8999
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 Range}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3 to 168}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1 to 167}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 4 to 167}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1 to 168}\cell
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 }\cell
+\intbl\row\pard
+\trowd\trgaph108\trleft0\trqc
+\clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrdb\brdrw15\clvertalt\cellx9000
+\pard\hyphpar0\sb15\sa15\fi0\li0\ri0\ql\fs18{\f0 SD=Standard deviation; SE=Standard error; Q1=First quartile, Q3=Third quartile.\line Each participant is counted once on each applicable duration category row.\line Duration of Exposure is the time from the first dose date to the last dose date.}\cell
+\intbl\row\pard
+{\pard\hyphpar\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 Source:  [CDISCpilot: adam-adexsum]}\par}
+
+}


### PR DESCRIPTION
1. exp_duration.Rmd: create vignettes for exposure duration table
2. rtf_sl_summary.R: #112 updated to fix the duplicate stats footnote
3. exp0duration.rtf: exposure duration table output