### PR TITLE
Update DESCRIPTION based on cran's comment

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: metalite.sl
-Title: Subject-level Analysis Using 'metalite'
+Title: Subject-Level Analysis Using 'metalite'
 Version: 0.1.0
 Authors@R: c(
     person("Benjamin", "Wang", email = "benjamin.wang@merck.com", role = c("aut", "cre")),
@@ -12,7 +12,12 @@ Authors@R: c(
     person("Chen", "Wang", role = "ctb"),
     person("Merck Sharp & Dohme Corp", role = "cph")
     )
-Description: Provide subject-level analysis.
+Description: Analyzes subject-level data in clinical trials using the 'metalite'
+    data structure. The package simplifies the workflow to create
+    production-ready tables, listings, and figures discussed in the
+    subject-level analysis chapters of
+    "R for Clinical Study Reports and Submission"
+    by Zhang et al. (2022) <https://r4csr.org/>.
 Depends: R (>= 4.1.0)
 License: GPL (>= 3)
 Imports:


### PR DESCRIPTION
Got following comments from CRAN:
   The Title field should be in title case. Current version is:
     'Subject-level Analysis Using 'metalite''
   In title case that is:
     'Subject-Level Analysis Using 'metalite''

Please fix and resubmit.

Please elaborate in the Description field what this is baout.
Is there some reference about the method you can add in the Description 
field in the form Authors (year) <doi:10.....>?
