### PR TITLE
Remove seed setting and replace `\dontrun{}` with `\donttest{}`

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,4 @@
 ^\.github$
 ^codecov\.yml$
 ^tests/testthat/_snaps$
+^cran-comments\.md$

--- a/R/meta_sl_example.R
+++ b/R/meta_sl_example.R
@@ -179,7 +179,6 @@ meta_sl_exposure_example <- function() {
   adexsum$APERIODC <- "Base"
   adexsum$APERIOD <- 1
 
-  set.seed(123) # Set a seed for reproducibility
   adexsum$AVAL <- sample(x = 0:(24 * 7), size = length(adexsum$USUBJID), replace = TRUE)
   adexsum$EXDURGR <- "not treated"
   adexsum$EXDURGR[adexsum$AVAL >= 1] <- ">=1 day and <7days"

--- a/R/rtf_base_char_subgroup.R
+++ b/R/rtf_base_char_subgroup.R
@@ -31,7 +31,7 @@
 #' @export
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' meta <- meta_sl_example()
 #'
 #' outdata <- prepare_base_char_subgroup(

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,6 @@
+## Resubmission v0.1.0
+
+This is a resubmission. In this version, I have fixed the issues identified in v0.1.0:
+
+-   Remove seed setting in `meta_sl_example()` to avoid to specify a seed in a function.
+-   Replace `dontrun{}` to `donttest{}` for an example of `rtf_base_char_subgroup()`.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -3,4 +3,4 @@
 This is a resubmission. In this version, I have fixed the issues identified in v0.1.0:
 
 -   Remove seed setting in `meta_sl_example()` to avoid to specify a seed in a function.
--   Replace `dontrun{}` to `donttest{}` for an example of `rtf_base_char_subgroup()`.
+-   Replace `\dontrun{}` with `\donttest{}` for an example of `rtf_base_char_subgroup()`.

--- a/man/rtf_base_char_subgroup.Rd
+++ b/man/rtf_base_char_subgroup.Rd
@@ -45,7 +45,7 @@ RTF file and source dataset for baseline characteristic table.
 Subgroup Analysis for Baseline Characteristic
 }
 \examples{
-\dontrun{
+\donttest{
 meta <- meta_sl_example()
 
 outdata <- prepare_base_char_subgroup(

--- a/tests/testthat/test-independent-testing-rtf_exp_duration.R
+++ b/tests/testthat/test-independent-testing-rtf_exp_duration.R
@@ -1,5 +1,6 @@
 library(metalite)
 
+set.seed(123)
 metatest <- meta_sl_exposure_example()
 
 outdata <- prepare_sl_summary(


### PR DESCRIPTION
This PR updates:

 - `meta_sl_example()` to remove seed setting.
 - `rtf_base_char_subgroup` to replace `\dontrun{}` with `\donttest{}`.

Also, `cran-comments.md` is added.
These are based on the CRAN's feedback for v0.1.0 release as below:

>  \dontrun{} should only be used if the example really cannot be executed (e.g. because of missing additional software, missing API keys, ...) by the user. That's why wrapping examples in \dontrun{} adds the comment ("# Not run:") as a warning for the user. Does not seem necessary.
Please replace \dontrun with \donttest.
Only functions which are supposed to only run interactively (e.g. shiny) should be wrapped in if(interactive()). Please replace if(interactive()){} if possible.

> Please do not set a seed to a specific number within a function. -> R/meta_sl_example.R