### PR TITLE
Default category setting for `extend_exp_duration()`

### DIFF
--- a/R/extend_exp_duration.R
+++ b/R/extend_exp_duration.R
@@ -174,7 +174,7 @@ extend_exp_duration <- function(outdata,
   if (is.null(duration_category_list) & !is.null(par_var_group)) {
     count <- char_n[1:(which(is.na(char_n$name)) - 1), ]
     prop <- char_prop[1:(which(is.na(char_prop$name)) - 1), ]
-    
+
     outdata$char_n_cum <- count |> list()
     outdata$char_prop_cum <- prop |> list()
     if (!is.null(outdata$char_stat_groups)) {

--- a/R/extend_exp_duration.R
+++ b/R/extend_exp_duration.R
@@ -43,9 +43,9 @@
 #'     duration_category_labels = c(">=1 day", ">=7 days", ">=28 days", ">=12 weeks", ">=24 weeks")
 #'   )
 extend_exp_duration <- function(outdata,
-                                category_section_label = NULL,
-                                duration_category_list = NULL,
-                                duration_category_labels = NULL) {
+                                category_section_label = paste0(metalite::collect_adam_mapping(outdata$meta, outdata$parameter)$label, " (extend)"),
+                                duration_category_list = extract_duration_category_ranges(duration_category_labels),
+                                duration_category_labels = levels(outdata$meta$data_population[[metalite::collect_adam_mapping(outdata$meta, outdata$parameter)$vargroup]])) {
   res <- outdata
   meta <- res$meta
   analysis <- res$analysis
@@ -170,17 +170,6 @@ extend_exp_duration <- function(outdata,
       }
     }
   }
-  # Duration category is not specified
-  if (is.null(duration_category_list) & !is.null(par_var_group)) {
-    count <- char_n[1:(which(is.na(char_n$name)) - 1), ]
-    prop <- char_prop[1:(which(is.na(char_prop$name)) - 1), ]
-
-    outdata$char_n_cum <- count |> list()
-    outdata$char_prop_cum <- prop |> list()
-    if (!is.null(outdata$char_stat_groups)) {
-      outdata$char_stat_cums <- outdata$char_stat_groups
-    }
-  }
   # Duration category is specified
   if (!is.null(duration_category_list) & !is.null(par_var)) {
     data_population$TRTDURGR <- NA
@@ -202,10 +191,6 @@ extend_exp_duration <- function(outdata,
       # Create metadata for subgroup
       pop_subset <- metalite::collect_adam_mapping(meta, population)$subset
       pop_subset <- rlang::quo(TRTDURGR == !!label & !!pop_subset)
-
-      if (is.null(category_section_label)) {
-        category_section_label <- paste0(metalite::collect_adam_mapping(meta, parameter)$label, " (cumulative)")
-      }
 
       meta_cum <- meta_sl(
         data_population,

--- a/R/extend_exp_duration.R
+++ b/R/extend_exp_duration.R
@@ -76,7 +76,6 @@ extend_exp_duration <- function(outdata,
   }
 
   char_n <- res$char_n[[1]]
-  char_prop <- res$char_prop[[1]]
   observation <- meta$plan[meta$plan$analysis == analysis, ]$observation
 
   # obtain variables

--- a/R/extend_exp_duration.R
+++ b/R/extend_exp_duration.R
@@ -76,6 +76,7 @@ extend_exp_duration <- function(outdata,
   }
 
   char_n <- res$char_n[[1]]
+  char_prop <- res$char_prop[[1]]
   observation <- meta$plan[meta$plan$analysis == analysis, ]$observation
 
   # obtain variables
@@ -167,6 +168,17 @@ extend_exp_duration <- function(outdata,
         char_stat_groups[[label]] <- sum
         outdata$char_stat_groups <- char_stat_groups
       }
+    }
+  }
+  # Duration category is not specified
+  if (is.null(duration_category_list) & !is.null(par_var_group)) {
+    count <- char_n[1:(which(is.na(char_n$name)) - 1), ]
+    prop <- char_prop[1:(which(is.na(char_prop$name)) - 1), ]
+    
+    outdata$char_n_cum <- count |> list()
+    outdata$char_prop_cum <- prop |> list()
+    if (!is.null(outdata$char_stat_groups)) {
+      outdata$char_stat_cums <- outdata$char_stat_groups
     }
   }
   # Duration category is specified

--- a/R/meta_sl_example.R
+++ b/R/meta_sl_example.R
@@ -180,14 +180,14 @@ meta_sl_exposure_example <- function() {
   adexsum$APERIOD <- 1
 
   adexsum$AVAL <- sample(x = 1:(24 * 7), size = length(adexsum$USUBJID), replace = TRUE)
-  adexsum$EXDURGR[adexsum$AVAL >= 1] <- ">=1 day and <7days"
+  adexsum$EXDURGR[adexsum$AVAL >= 1] <- ">=1 day and <7 days"
   adexsum$EXDURGR[adexsum$AVAL >= 7] <- ">=7 days and <28 days"
   adexsum$EXDURGR[adexsum$AVAL >= 28] <- ">=28 days and <12 weeks"
   adexsum$EXDURGR[adexsum$AVAL >= 12 * 7] <- ">=12 weeks and <24 weeks"
   adexsum$EXDURGR[adexsum$AVAL >= 24 * 7] <- ">=24 weeks"
 
   adexsum$EXDURGR <- factor(adexsum$EXDURGR,
-    levels = c(">=1 day and <7days", ">=7 days and <28 days", ">=28 days and <12 weeks", ">=12 weeks and <24 weeks", ">=24 weeks")
+    levels = c(">=1 day and <7 days", ">=7 days and <28 days", ">=28 days and <12 weeks", ">=12 weeks and <24 weeks", ">=24 weeks")
   )
 
   plan <- metalite::plan(

--- a/R/plotly_exp_duration.R
+++ b/R/plotly_exp_duration.R
@@ -354,7 +354,7 @@ plotly_exp_duration <- function(outdata,
     stop("No plot is available. Please check the input data.")
   }
 
-  histograms <- names(p)
+  histograms <- plot_type_label
   histograms_ids <- paste0("histogram_type_", uuid::UUIDgenerate(), "|", histograms)
   plot_divs <- lapply(histograms_ids, function(x) {
     element <- unlist(strsplit(x, "\\|"))[2]

--- a/R/utils.R
+++ b/R/utils.R
@@ -70,7 +70,7 @@ extract_duration_category_ranges <- function(labels) {
       }
       as.numeric(x)
     })
-  
+
   factors <- labels |>
     stringr::str_extract_all(pattern = "\\d+ ?([a-zA-Z]+)") |>
     lapply(
@@ -93,10 +93,10 @@ extract_duration_category_ranges <- function(labels) {
         return(factor)
       }
     )
-  
+
   list <- lapply(
     seq_along(times),
-    function (x) {
+    function(x) {
       if (length(times[[x]]) < 2) {
         time <- c(times[[x]], rep(NA, 2 - length(times[[x]])))
       } else {

--- a/R/utils.R
+++ b/R/utils.R
@@ -55,3 +55,62 @@ rtf_output <- function(
 
   invisible(outdata)
 }
+
+#' Obtain a list of category ranges from a character label for exposure duration analysis
+#'
+#' @param labels A character vector of a category label
+#'
+#' @noRd
+extract_duration_category_ranges <- function(labels) {
+  times <- labels |>
+    stringr::str_extract_all(pattern = "\\d+") |>
+    lapply(function(x) {
+      if (length(x) == 0) {
+        stop("A real number for duration category is not recognized. Please rename the category label in the input data, or use `duration_category_list` and `duration_category_labels`.")
+      }
+      as.numeric(x)
+    })
+  
+  factors <- labels |>
+    stringr::str_extract_all(pattern = "\\d+ ?([a-zA-Z]+)") |>
+    lapply(
+      function(x) {
+        unit <- stringr::str_extract(x, pattern = "\\d+ ?([a-zA-Z])", group = 1)
+        factor <- sapply(unit, USE.NAMES = FALSE, function(y) {
+          if (toupper(y) == "D") {
+            1
+          } else if (toupper(y) == "W") {
+            7
+          } else if (toupper(y) == "M") {
+            30.4367
+          } else if (toupper(y) == "Y") {
+            365.24
+          } else {
+            warning("The unit of duration category is not recognized. The unit is handled as day(s).")
+            1
+          }
+        })
+        return(factor)
+      }
+    )
+  
+  list <- lapply(
+    seq_along(times),
+    function (x) {
+      if (length(times[[x]]) < 2) {
+        time <- c(times[[x]], rep(NA, 2 - length(times[[x]])))
+      } else {
+        time <- times[[x]]
+      }
+      if (length(factors[[x]]) == 1) {
+        factor <- rep(factors[[x]], 2)
+      } else if (length(factors[[x]]) == 0) {
+        factor <- rep(1, 2)
+      } else {
+        factor <- factors[[x]]
+      }
+      return(time * factor)
+    }
+  )
+  return(list)
+}

--- a/man/extend_exp_duration.Rd
+++ b/man/extend_exp_duration.Rd
@@ -6,9 +6,12 @@
 \usage{
 extend_exp_duration(
   outdata,
-  category_section_label = NULL,
-  duration_category_list = NULL,
-  duration_category_labels = NULL
+  category_section_label = paste0(metalite::collect_adam_mapping(outdata$meta,
+    outdata$parameter)$label, " (extend)"),
+  duration_category_list = extract_duration_category_ranges(duration_category_labels),
+  duration_category_labels =
+    levels(outdata$meta$data_population[[metalite::collect_adam_mapping(outdata$meta,
+    outdata$parameter)$vargroup]])
 )
 }
 \arguments{
@@ -38,7 +41,7 @@ meta <- meta_sl_exposure_example()
 outdata <- meta |> prepare_exp_duration()
 outdata |>
   extend_exp_duration(
-    duration_category_list = list(c(1, NA), c(7, NA), c(28, NA), c(12*7, NA), c(24*7, NA)),
+    duration_category_list = list(c(1, NA), c(7, NA), c(28, NA), c(12 * 7, NA), c(24 * 7, NA)),
     duration_category_labels = c(">=1 day", ">=7 days", ">=28 days", ">=12 weeks", ">=24 weeks")
   )
 }

--- a/man/plotly_exp_duration.Rd
+++ b/man/plotly_exp_duration.Rd
@@ -58,7 +58,7 @@ if (interactive()) {
   outdata <- meta |>
     prepare_exp_duration() |>
     extend_exp_duration(
-      duration_category_list = list(c(1, NA), c(7, NA), c(28, NA), c(12*7, NA), c(24*7, NA)),
+      duration_category_list = list(c(1, NA), c(7, NA), c(28, NA), c(12 * 7, NA), c(24 * 7, NA)),
       duration_category_labels = c(">=1 day", ">=7 days", ">=28 days", ">=12 weeks", ">=24 weeks")
     )
 

--- a/tests/testthat/_snaps/independent-testing-rtf_exp_duration/exp0duration1.rtf
+++ b/tests/testthat/_snaps/independent-testing-rtf_exp_duration/exp0duration1.rtf
@@ -74,7 +74,7 @@
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7000
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8000
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx9000
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 \uc1\u8805* 1 day and <7days}\cell
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 \uc1\u8805* 1 day and <7 days}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.16)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell

--- a/tests/testthat/_snaps/independent-testing-rtf_exp_duration/exp0duration2.rtf
+++ b/tests/testthat/_snaps/independent-testing-rtf_exp_duration/exp0duration2.rtf
@@ -86,7 +86,7 @@
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx10016
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx11129
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx12242
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 \uc1\u8805* 1 day and <7days}\cell
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 \uc1\u8805* 1 day and <7 days}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell

--- a/tests/testthat/_snaps/independent-testing-rtf_exp_duration/exp0duration3.rtf
+++ b/tests/testthat/_snaps/independent-testing-rtf_exp_duration/exp0duration3.rtf
@@ -86,7 +86,7 @@
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx6544
 \clbrdrl\brdrs\brdrw15\clbrdrt\brdrw15\clbrdrb\brdrw15\clvertalt\cellx7771
 \clbrdrl\brdrw15\clbrdrt\brdrw15\clbrdrr\brdrs\brdrw15\clbrdrb\brdrw15\clvertalt\cellx8998
-\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 \uc1\u8805* 1 day and <7days}\cell
+\pard\hyphpar0\sb15\sa15\fi100\li100\ri0\ql\fs18{\f0 \uc1\u8805* 1 day and <7 days}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 1}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0  (1.2)}\cell
 \pard\hyphpar0\sb15\sa15\fi0\li0\ri0\qc\fs18{\f0 3}\cell


### PR DESCRIPTION
This PR sets default values for the arguments of `extend_exp_duration()` so that it uses metadata, and adds `extract_duration_category_ranges()` to obtain real numbers from labels for exposure duration categories. Also, updates `plotly_exp_duration()` to align the display order of histogram type with that of `plot_type_label`.