### PR TITLE
Testing `prepare_sl_summary()` and `prepare_base_char()`

### DIFF
--- a/tests/testthat/test-independent-testing-prepare_sl_summary.R
+++ b/tests/testthat/test-independent-testing-prepare_sl_summary.R
@@ -65,7 +65,7 @@ meta_test <- meta_adam(
   )
 
 # Prepare test data by the tested function
-test_meta_base_char <- prepare_base_char(
+test_meta_base_char <- prepare_sl_summary(
   meta_test,
   population = "apat",
   analysis = "base_char",
@@ -343,6 +343,6 @@ test_that("Parameter matching", {
   expect_equal(test_meta_base_char$parameter, "age;agen;gender;race")
 })
 
-test_that("Output from prepare_base_char is a list", {
+test_that("Output from prepare_sl_summary is a list", {
   expect_true("outdata" %in% class(test_meta_base_char))
 })


### PR DESCRIPTION
This PR adds test for `prepare_sl_summary()` and update `test-independent-testing-prepare_base_char.R` to rename `prepare_sl_summary()` to `prepare_base_char()`.